### PR TITLE
Add memory-based loaders and embedded file size

### DIFF
--- a/src/hpdf/doc.cr
+++ b/src/hpdf/doc.cr
@@ -185,6 +185,20 @@ module Hpdf
       String.new(LibHaru.load_tt_font_from_file2(self, file_name, uint(index), bool(embedding)))
     end
 
+    # loads a TrueType font from a file path or a `Bytes` buffer and returns
+    # the font name. The font name can be passed to `Doc#font`.
+    #
+    # * *source* a file path (`String` or `Path`) or raw font data (`Bytes`).
+    # * *embedding* if `true` the glyph data is embedded in the PDF.
+    def load_tt_font(source : String | Path, embedding : Bool = true) : String
+      String.new(LibHaru.load_tt_font_from_file(self, source.to_s, bool(embedding)))
+    end
+
+    # :ditto:
+    def load_tt_font(source : Bytes, embedding : Bool = true) : String
+      String.new(LibHaru.load_tt_font_from_mem(self, source.to_unsafe, uint(source.size), bool(embedding)))
+    end
+
     # adds a page labeling range for the document.
     #
     # * *page_num* the first page that applies this labeling range.
@@ -305,6 +319,24 @@ module Hpdf
       else
         Image.new(LibHaru.load_png_image_from_file(self, file_name), self)
       end
+    end
+
+    # loads a PNG image from a file path or a `Bytes` buffer.
+    #
+    # * *source* a file path (`String` or `Path`) or raw PNG data (`Bytes`).
+    # * *lazy* (file only) if `true`, defers loading the pixel data until the PDF
+    #   is written, which reduces peak memory usage for large images.
+    def load_png_image(source : String | Path, lazy : Bool = false) : Image
+      if lazy
+        Image.new(LibHaru.load_png_image_from_file2(self, source.to_s), self)
+      else
+        Image.new(LibHaru.load_png_image_from_file(self, source.to_s), self)
+      end
+    end
+
+    # :ditto:
+    def load_png_image(source : Bytes) : Image
+      Image.new(LibHaru.load_png_image_from_mem(self, source.to_unsafe, uint(source.size)), self)
     end
 
     # loads an image which has "raw" image format.
@@ -600,6 +632,36 @@ module Hpdf
       Image.new(LibHaru.load_jpeg_image_from_file(self, file_name), self)
     end
 
+    # loads a JPEG image from a file path or a `Bytes` buffer.
+    #
+    # * *source* a file path (`String` or `Path`) or raw JPEG data (`Bytes`).
+    def load_jpeg_image(source : String | Path) : Image
+      Image.new(LibHaru.load_jpeg_image_from_file(self, source.to_s), self)
+    end
+
+    # :ditto:
+    def load_jpeg_image(source : Bytes) : Image
+      Image.new(LibHaru.load_jpeg_image_from_mem(self, source.to_unsafe, uint(source.size)), self)
+    end
+
+    # loads a 1-bit bilevel image from a `Bytes` buffer.
+    # Each row occupies *line_width* bytes; individual pixels are packed MSB-first.
+    #
+    # * *source* raw image data.
+    # * *width* image width in pixels.
+    # * *height* image height in pixels.
+    # * *line_width* byte width of one scanline (must be ≥ ⌈*width*/8⌉).
+    # * *black_is1* if `true`, a set bit is black; if `false`, a set bit is white.
+    # * *top_is_first* if `true`, the first byte row is the top of the image.
+    def load_raw1_bit_image(source : Bytes, *, width : Number, height : Number,
+                            line_width : Number, black_is1 : Bool = true,
+                            top_is_first : Bool = true) : Image
+      Image.new(LibHaru.image_load_raw1_bit_image_from_mem(
+        self, source.to_unsafe, uint(width), uint(height), uint(line_width),
+        bool(black_is1), bool(top_is_first)
+      ), self)
+    end
+
     # creates a new extended graphics state object. Use it to set transparency
     # and blend modes on a page via `Page#ext_g_state=`.
     def create_ext_g_state : ExtGState
@@ -770,6 +832,7 @@ module Hpdf
     # * *description* optional human-readable description of the attachment.
     # * *subtype* MIME type of the attached file (default: `"text/xml"`).
     # * *relationship* how the attachment relates to the document (see `AFRelationship`).
+    # * *size* optional file size in bytes stored in the attachment metadata.
     # * *creation_date* optional creation timestamp stored in the attachment metadata.
     # * *modification_date* optional last-modification timestamp stored in the attachment metadata.
     def attach_file(path : String, *,
@@ -777,6 +840,7 @@ module Hpdf
                     description : String? = nil,
                     subtype : String = "text/xml",
                     relationship : AFRelationship = AFRelationship::Alternative,
+                    size : UInt64? = nil,
                     creation_date : Time? = nil,
                     modification_date : Time? = nil) : self
       ef = LibHaru.attach_file(self, path)
@@ -784,6 +848,7 @@ module Hpdf
       LibHaru.embedded_file_set_subtype(ef, subtype)
       LibHaru.embedded_file_set_af_relationship(ef, LibHaru::AFRelationship.new(relationship.value.to_u32))
       LibHaru.embedded_file_set_description(ef, description) if description
+      LibHaru.embedded_file_set_size(ef, size) if size
       LibHaru.embedded_file_set_creation_date(ef, Date.new(creation_date).to_unsafe) if creation_date
       LibHaru.embedded_file_set_last_modification_date(ef, Date.new(modification_date).to_unsafe) if modification_date
       self

--- a/src/hpdf/image.cr
+++ b/src/hpdf/image.cr
@@ -2,9 +2,9 @@ module Hpdf
   # The image is used to display image to a page mainly. To create/load
   # an image use:
   #
-  # * **PNG** `Doc#load_png_image_from_file`
-  # * **RAW** `Doc#load_raw_image_from_file` or `Doc#load_raw_image_from_mem`
-  # * **JPEG** `Doc#load_jpeg_image_from_file`
+  # * **PNG** `Doc#load_png_image_from_file` or `Doc#load_png_image`
+  # * **JPEG** `Doc#load_jpeg_image_from_file` or `Doc#load_jpeg_image`
+  # * **RAW** `Doc#load_raw_image_from_file`, `Doc#load_raw_image_from_mem`, or `Doc#load_raw1_bit_image`
   class Image
     include Helper
 
@@ -19,6 +19,14 @@ module Hpdf
     def size : Size
       s = LibHaru.image_get_size(self)
       Size.new(width: s.x.to_u32, height: s.y.to_u32)
+    end
+
+    # gets the size of the image via an out-parameter variant of `#size`.
+    # Both methods return the same value; this one exists for completeness.
+    def size2 : Size
+      pt = LibHaru::Point.new
+      LibHaru.image_get_size2(self, pointerof(pt))
+      Size.new(width: pt.x.to_u32, height: pt.y.to_u32)
     end
 
     # gets the width of the image of an image object.
@@ -67,6 +75,14 @@ module Hpdf
     #   This image must be 1bit gray-scale color image.
     def mask_image=(mask : Image)
       LibHaru.image_set_mask_image(self, mask)
+    end
+
+    # attaches a soft-mask image to this image for per-pixel opacity control.
+    # The soft mask must be a grayscale image: white = fully opaque, black = fully transparent.
+    #
+    # * *smask* the grayscale `Image` to use as a soft mask.
+    def smask=(smask : Image)
+      LibHaru.image_add_smask(self, smask)
     end
   end
 end

--- a/src/hpdf/libharu.cr
+++ b/src/hpdf/libharu.cr
@@ -112,6 +112,7 @@ lib LibHaru
   fun load_type1_font_from_file = HPDF_LoadType1FontFromFile(Doc, LibC::Char*, LibC::Char*) : LibC::Char*
   fun load_tt_font_from_file = HPDF_LoadTTFontFromFile(Doc, LibC::Char*, Bool) : LibC::Char*
   fun load_tt_font_from_file2 = HPDF_LoadTTFontFromFile2(Doc, LibC::Char*, UInt, Bool) : Status
+  fun load_tt_font_from_mem = HPDF_LoadTTFontFromMemory(Doc, UInt8*, UInt, Bool) : LibC::Char*
   fun add_page_label = HPDF_AddPageLabel(Doc, UInt, UInt, UInt, LibC::Char*) : Status
   fun use_jp_fonts = HPDF_UseJPFonts(Doc) : Status
   fun use_kr_fonts = HPDF_UseKRFonts(Doc) : Status
@@ -131,6 +132,9 @@ lib LibHaru
   fun load_raw_image_from_file = HPDF_LoadRawImageFromFile(Doc, LibC::Char*, UInt, UInt, UInt) : Image
   fun load_raw_image_from_mem = HPDF_LoadRawImageFromMem(Doc, LibC::Char*, UInt, UInt, UInt, UInt) : Image
   fun load_jpeg_image_from_file = HPDF_LoadJpegImageFromFile(Doc, LibC::Char*) : Image
+  fun load_png_image_from_mem = HPDF_LoadPngImageFromMem(Doc, UInt8*, UInt) : Image
+  fun load_jpeg_image_from_mem = HPDF_LoadJpegImageFromMem(Doc, UInt8*, UInt) : Image
+  fun image_load_raw1_bit_image_from_mem = HPDF_Image_LoadRaw1BitImageFromMem(Doc, UInt8*, UInt, UInt, UInt, Bool, Bool) : Image
   fun set_info_attr = HPDF_SetInfoAttr(Doc, UInt, LibC::Char*) : Status
   fun get_info_attr = HPDF_GetInfoAttr(Doc, UInt) : LibC::Char*
   fun set_info_date_attr = HPDF_SetInfoDateAttr(Doc, UInt, Date) : Status
@@ -184,6 +188,7 @@ lib LibHaru
   fun embedded_file_set_af_relationship = HPDF_EmbeddedFile_SetAFRelationship(EmbeddedFile, AFRelationship) : Status
   fun embedded_file_set_creation_date = HPDF_EmbeddedFile_SetCreationDate(EmbeddedFile, Date) : Status
   fun embedded_file_set_last_modification_date = HPDF_EmbeddedFile_SetLastModificationDate(EmbeddedFile, Date) : Status
+  fun embedded_file_set_size = HPDF_EmbeddedFile_SetSize(EmbeddedFile, UInt64) : Status
 
   # Page handling
   fun page_set_width = HPDF_Page_SetWidth(Page, Real) : Status
@@ -335,12 +340,14 @@ lib LibHaru
 
   # Image
   fun image_get_size = HPDF_Image_GetSize(Image) : Point
+  fun image_get_size2 = HPDF_Image_GetSize2(Image, Point*) : Status
   fun image_get_width = HPDF_Image_GetWidth(Image) : UInt
   fun image_get_height = HPDF_Image_GetHeight(Image) : UInt
   fun image_get_bits_per_component = HPDF_Image_GetBitsPerComponent(Image) : UInt
   fun image_get_color_space = HPDF_Image_GetColorSpace(Image) : LibC::Char*
   fun image_set_color_mask = HPDF_Image_SetColorMask(Image, UInt, UInt, UInt, UInt, UInt, UInt) : Status
   fun image_set_mask_image = HPDF_Image_SetMaskImage(Image, Image) : Status
+  fun image_add_smask = HPDF_Image_AddSMask(Image, Image) : Status
 
   # Exception codes
   HPDF_ARRAY_COUNT_ERR              = 0x1001 #	Internal error. The consistency of the data was lost.


### PR DESCRIPTION
## Summary

- **Font loading:** `Doc#load_tt_font` now accepts `String | Path` (file) or `Bytes` (memory buffer), dispatching to the right libharu binding via Crystal overloads. The existing `load_tt_font_from_file` is unchanged.
- **Image loading:** `Doc#load_png_image` and `Doc#load_jpeg_image` each gain a `Bytes` overload alongside the `String | Path` variant. `load_png_image` carries a `lazy:` keyword for deferred pixel loading on the file path. `Doc#load_raw1_bit_image` is a new method for 1-bit bilevel images loaded from a buffer, with named keyword params (`width:`, `height:`, `line_width:`, `black_is1:`, `top_is_first:`).
- **Image soft-mask:** `Image#smask=` attaches a grayscale soft-mask image for per-pixel opacity (`HPDF_Image_AddSMask`).
- **Image size (out-param variant):** `Image#size2` returns the image dimensions via the out-parameter variant of `HPDF_Image_GetSize2`.
- **Embedded file size metadata:** `Doc#attach_file` gains an optional `size : UInt64?` keyword parameter stored via `HPDF_EmbeddedFile_SetSize`.

All existing `*_from_file` methods are kept for backward compatibility.