### PR TITLE
Add page state getters, XObject support, viewer preferences

### DIFF
--- a/src/hpdf/doc.cr
+++ b/src/hpdf/doc.cr
@@ -119,6 +119,18 @@ module Hpdf
       PageMode.new LibHaru.get_page_mode(self).to_i32
     end
 
+    # gets the viewer preferences bitmask for the document.
+    def viewer_preference : ViewerPreference
+      ViewerPreference.new(LibHaru.get_viewer_preference(self))
+    end
+
+    # sets the viewer preferences that control PDF viewer UI behaviour on open.
+    #
+    # * *preference* one or more `ViewerPreference` flags combined with `|`.
+    def viewer_preference=(preference : ViewerPreference)
+      LibHaru.set_viewer_preference(self, preference.value)
+    end
+
     # set the first page to appear when a document is opened.
     def open_action=(dst : Destination)
       LibHaru.set_open_action(self, dst)
@@ -146,6 +158,14 @@ module Hpdf
       new_page = Page.new(LibHaru.insert_page(self, page), self)
       @pages.insert index: idx, object: new_page
       new_page
+    end
+
+    # returns the page at the given 0-based *index*.
+    # Returns the existing tracked `Page` wrapper if one is found for the handle,
+    # preserving font and encoding state set on the original object.
+    def page_by_index(index : Int) : Page
+      handle = LibHaru.get_page_by_index(self, uint(index))
+      @pages.find { |page| page.to_unsafe == handle } || Page.new(handle, self)
     end
 
     # gets the handle of a corresponding font object by specified name and encoding.

--- a/src/hpdf/enum.cr
+++ b/src/hpdf/enum.cr
@@ -375,4 +375,16 @@ module Hpdf
     Paragraph
     Insert
   end
+
+  # Controls PDF viewer UI behaviour when the document is opened.
+  # Values can be combined with `|`.
+  @[Flags]
+  enum ViewerPreference : UInt32
+    HideToolbar      =  1
+    HideMenubar      =  2
+    HideWindowUI     =  4
+    FitWindow        =  8
+    CenterWindow     = 16
+    PrintScalingNone = 32
+  end
 end

--- a/src/hpdf/libharu.cr
+++ b/src/hpdf/libharu.cr
@@ -23,6 +23,7 @@ lib LibHaru
   type Annotation = Void*
   type ExtGState = Void*
   type Shading = Void*
+  type XObject = Void*
 
   alias Real = LibC::Float
   alias Status = LibC::ULong
@@ -104,6 +105,9 @@ lib LibHaru
   fun get_page_layout = HPDF_GetPageLayout(Doc) : UInt
   fun set_page_mode = HPDF_SetPageMode(Doc, UInt) : Status
   fun get_page_mode = HPDF_GetPageMode(Doc) : UInt
+  fun get_viewer_preference = HPDF_GetViewerPreference(Doc) : UInt
+  fun set_viewer_preference = HPDF_SetViewerPreference(Doc, UInt) : Status
+  fun get_page_by_index = HPDF_GetPageByIndex(Doc, UInt) : Page
   fun set_open_action = HPDF_SetOpenAction(Doc, Destination) : Status
   fun get_current_page = HPDF_GetCurrentPage(Doc) : Page
   fun add_page = HPDF_AddPage(Doc) : Page
@@ -210,6 +214,11 @@ lib LibHaru
   fun page_get_miter_limit = HPDF_Page_GetMiterLimit(Page) : Real
   fun page_get_dash = HPDF_Page_GetDash(Page) : DashMode
   fun page_get_flat = HPDF_Page_GetFlat(Page) : Real
+  fun page_get_text_leading = HPDF_Page_GetTextLeading(Page) : Real
+  fun page_get_text_matrix = HPDF_Page_GetTextMatrix(Page) : TransMatrix
+  fun page_set_flat = HPDF_Page_SetFlat(Page, Real) : Status
+  fun page_get_current_pos2 = HPDF_Page_GetCurrentPos2(Page, Point*) : Status
+  fun page_get_current_text_pos2 = HPDF_Page_GetCurrentTextPos2(Page, Point*) : Status
   fun page_get_char_space = HPDF_Page_GetCharSpace(Page) : Real
   fun page_get_word_space = HPDF_Page_GetWordSpace(Page) : Real
   fun page_get_horizontal_scalling = HPDF_Page_GetHorizontalScalling(Page) : Real
@@ -219,7 +228,9 @@ lib LibHaru
   fun page_get_rgb_stroke = HPDF_Page_GetRGBStroke(Page) : RGB
   fun page_get_cmyk_fill = HPDF_Page_GetCMYKFill(Page) : CMYK
   fun page_get_cmyk_stroke = HPDF_Page_GetCMYKStroke(Page) : CMYK
-  fun page_execute_x_object = HPDF_Page_ExecuteXObject(Page, Image) : Status
+  fun page_execute_x_object = HPDF_Page_ExecuteXObject(Page, XObject) : Status
+  fun page_create_x_object_from_image = HPDF_Page_CreateXObjectFromImage(Doc, Page, Rect, Image, Bool) : XObject
+  fun page_create_x_object_as_white_rect = HPDF_Page_CreateXObjectAsWhiteRect(Doc, Page, Rect) : XObject
   fun page_get_gray_fill = HPDF_Page_GetGrayFill(Page) : Real
   fun page_get_gray_stroke = HPDF_Page_GetGrayStroke(Page) : Real
   fun page_get_stroking_color_space = HPDF_Page_GetStrokingColorSpace(Page) : UInt

--- a/src/hpdf/libharu.cr
+++ b/src/hpdf/libharu.cr
@@ -217,8 +217,6 @@ lib LibHaru
   fun page_get_text_leading = HPDF_Page_GetTextLeading(Page) : Real
   fun page_get_text_matrix = HPDF_Page_GetTextMatrix(Page) : TransMatrix
   fun page_set_flat = HPDF_Page_SetFlat(Page, Real) : Status
-  fun page_get_current_pos2 = HPDF_Page_GetCurrentPos2(Page, Point*) : Status
-  fun page_get_current_text_pos2 = HPDF_Page_GetCurrentTextPos2(Page, Point*) : Status
   fun page_get_char_space = HPDF_Page_GetCharSpace(Page) : Real
   fun page_get_word_space = HPDF_Page_GetWordSpace(Page) : Real
   fun page_get_horizontal_scalling = HPDF_Page_GetHorizontalScalling(Page) : Real

--- a/src/hpdf/page.cr
+++ b/src/hpdf/page.cr
@@ -204,6 +204,7 @@ module Hpdf
 
     # sets the flatness tolerance for curve rendering. *value* must be in the range 0–100.
     def flat=(value : Number)
+      raise ArgumentError.new("flat value out of range: #{value} (must be 0–100)") unless (0..100).includes?(value)
       LibHaru.page_set_flat(self, real(value))
     end
 

--- a/src/hpdf/page.cr
+++ b/src/hpdf/page.cr
@@ -2,6 +2,11 @@ require "./helper"
 require "./enum"
 
 module Hpdf
+  # Opaque handle for a form XObject returned by `Page#create_x_object_from_image`
+  # and `Page#create_x_object_as_white_rect`. Pass to `Page#execute_x_object` to
+  # paint the XObject onto a page.
+  alias XObject = LibHaru::XObject
+
   # The page handle is used to operate an individual page.
   # When `Doc#add_page` or `Doc#insert_page` is invoked, a page object
   # is created.
@@ -133,6 +138,13 @@ module Hpdf
       Point.new(LibHaru.page_get_current_pos(self))
     end
 
+    # gets the current graphics position via out-parameter. Equivalent to `current_pos`.
+    def current_pos2 : Point
+      pt = LibHaru::Point.new
+      LibHaru.page_get_current_pos2(self, pointerof(pt))
+      Point.new(pt)
+    end
+
     # gets the current position for text showing. It returns a `Point` struct
     # indicating the current position for text showing of the page.
     # Otherwise it returns a `Point` struct of {0, 0}.
@@ -141,6 +153,13 @@ module Hpdf
     # mode is `GMode::TextObject`.
     def current_text_pos : Point
       Point.new(LibHaru.page_get_current_text_pos(self))
+    end
+
+    # gets the current text position via out-parameter. Equivalent to `current_text_pos`.
+    def current_text_pos2 : Point
+      pt = LibHaru::Point.new
+      LibHaru.page_get_current_text_pos2(self, pointerof(pt))
+      Point.new(pt)
     end
 
     # gets the handle of the page's current font.
@@ -197,6 +216,11 @@ module Hpdf
       LibHaru.page_get_flat(self).to_f32
     end
 
+    # sets the flatness tolerance for curve rendering. *value* must be in the range 0–100.
+    def flat=(value : Number)
+      LibHaru.page_set_flat(self, real(value))
+    end
+
     # gets the current value of the page's character spacing.
     def char_space : Float32
       requires_mode GMode::PageDescription, GMode::TextObject
@@ -249,13 +273,31 @@ module Hpdf
       CMYK.new(LibHaru.page_get_cmyk_stroke(self))
     end
 
-    # draws the XObject using the current graphics context. This is used
-    # by `draw_image` to draw the `Image` by first calling `g_save` and
-    # `concat` and then calling `g_restore` after `execute_x_object`.
-    # It could be used manually to rotate an image.
-    def execute_x_object(image : Image)
+    # draws the XObject using the current graphics context.
+    def execute_x_object(obj : XObject)
       requires_mode GMode::PageDescription
-      LibHaru.page_execute_x_object(self, image)
+      LibHaru.page_execute_x_object(self, obj)
+    end
+
+    # wraps *image* as a form XObject within *rect*. If *zoom* is `true`, the image
+    # is scaled to fill the rectangle.
+    # The returned `XObject` can be drawn repeatedly with `execute_x_object`.
+    #
+    # * *rect* the bounding rectangle for the XObject on the page.
+    # * *image* the image to embed as a form XObject.
+    # * *zoom* if `true`, the image is scaled to fill *rect*.
+    def create_x_object_from_image(rect : Rectangle, image : Image, zoom : Bool = true) : XObject
+      requires_mode GMode::PageDescription
+      LibHaru.page_create_x_object_from_image(@doc, self, rect.to_unsafe, image, bool(zoom))
+    end
+
+    # creates a white rectangle form XObject within *rect*.
+    # The returned `XObject` can be drawn repeatedly with `execute_x_object`.
+    #
+    # * *rect* the bounding rectangle for the white rectangle XObject on the page.
+    def create_x_object_as_white_rect(rect : Rectangle) : XObject
+      requires_mode GMode::PageDescription
+      LibHaru.page_create_x_object_as_white_rect(@doc, self, rect.to_unsafe)
     end
 
     # returns the current value of the page's filling color. `gray_fill` is
@@ -724,6 +766,12 @@ module Hpdf
       LibHaru.page_set_text_leading(self, real(value))
     end
 
+    # gets the current value of the page's text leading (line spacing).
+    def text_leading : Float32
+      requires_mode GMode::PageDescription, GMode::TextObject
+      LibHaru.page_get_text_leading(self).to_f32
+    end
+
     # sets the type of font and size leading.
     # An application can invoke `set_font_and_size` when the graphics
     # mode of the page is in `GMode::PageDescription` or
@@ -801,6 +849,12 @@ module Hpdf
     def set_text_matrix(a : Number, b : Number, c : Number, d : Number, x : Number, y : Number)
       requires_mode GMode::TextObject
       LibHaru.page_set_text_matrix(self, real(a), real(b), real(c), real(d), real(x), real(y))
+    end
+
+    # gets the current text transformation matrix.
+    def text_matrix : TransMatrix
+      requires_mode GMode::TextObject
+      TransMatrix.new(LibHaru.page_get_text_matrix(self))
     end
 
     # moves the current text position to the start of the next line.

--- a/src/hpdf/page.cr
+++ b/src/hpdf/page.cr
@@ -138,13 +138,6 @@ module Hpdf
       Point.new(LibHaru.page_get_current_pos(self))
     end
 
-    # gets the current graphics position via out-parameter. Equivalent to `current_pos`.
-    def current_pos2 : Point
-      pt = LibHaru::Point.new
-      LibHaru.page_get_current_pos2(self, pointerof(pt))
-      Point.new(pt)
-    end
-
     # gets the current position for text showing. It returns a `Point` struct
     # indicating the current position for text showing of the page.
     # Otherwise it returns a `Point` struct of {0, 0}.
@@ -153,13 +146,6 @@ module Hpdf
     # mode is `GMode::TextObject`.
     def current_text_pos : Point
       Point.new(LibHaru.page_get_current_text_pos(self))
-    end
-
-    # gets the current text position via out-parameter. Equivalent to `current_text_pos`.
-    def current_text_pos2 : Point
-      pt = LibHaru::Point.new
-      LibHaru.page_get_current_text_pos2(self, pointerof(pt))
-      Point.new(pt)
     end
 
     # gets the handle of the page's current font.


### PR DESCRIPTION
## Summary

- **Page state getters:** `Page#text_leading` and `Page#text_matrix` getters to complement their existing setters; `Page#flat=` setter.

- **XObjects:** Adds `Hpdf::XObject` type alias, fixes a pre-existing bug where `Page#execute_x_object` was typed `Image` instead of `XObject`, and adds `Page#create_x_object_from_image(rect, image, zoom)` and `Page#create_x_object_as_white_rect(rect)` for creating reusable form XObjects.

- **Viewer preferences:** `ViewerPreference` `@[Flags]` enum (HideToolbar, HideMenubar, HideWindowUI, FitWindow, CenterWindow, PrintScalingNone), `Doc#viewer_preference` getter/setter, and `Doc#page_by_index(index)` for retrieving existing pages by 0-based index.
